### PR TITLE
Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [1.1.0]
+### New
+- `Future` now takes a `pool` argument to specify a thread pool.
+- `Future` now implements `__call__` to allow `Future(f)("foo", k=42)` style to pass additional arguments.
+- `Future.deref()` now accepts an optional `timeout` parameter to avoid blocking forever.
+- Introduce `Deferred` object to encapsulate deferred results and re-throwing with original traceback.
+
+## [1.0.3]
+### New
+- Keep original traceback when re-throwing errors on realization of `pmap` generator.
+
+## [1.0.0]
+### New
+- Introduce `pmap` function for mapping over collection (lazily) in parallel.

--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,17 @@ from setuptools import setup, find_packages
 setup(
     name="python-pmap",
     description="Clojure's pmap implementation for Python.",
-    long_description = open("README.md").read(),
+    long_description=open("README.md").read(),
     author="Henrique Carvalho Alves",
     author_email="hcarvalhoalves@gmail.com",
     url="https://github.com/hcarvalhoalves/python-pmap",
     package_dir={'': 'src'},
     packages=find_packages('src'),
-    version="1.0.3",
-    install_requires=[],
+    version="1.1.0",
+    install_requires=[
+        "pytest",
+        "pytest-xdist"
+    ],
     dependency_links=[],
     include_package_data=True,
     zip_safe=False)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,14 @@ import traceback
 from pmap.core import *
 
 
+def always_fail(x):
+    raise ValueError(x)
+
+
+def maybe_fail(x):
+    return always_fail(x)
+
+
 def timeit(f):
     t = time.time()
     f()
@@ -11,53 +19,67 @@ def timeit(f):
 
 
 def test_future_deref():
-    f = Future(lambda: True)
-    assert f.deref() == True
+    f = Future(lambda x: 21 * x)
+    assert f(2).deref(1) == 42
 
 
-def test_future_timing():
+def test_future_deref_raise_original_traceback():
+    f = Future(maybe_fail)
+    try:
+        f("Monday").deref(1)
+    except ValueError as e:
+        assert str(e) == "Monday"
+        frames = traceback.extract_tb(sys.exc_info()[2])
+        # Traceback points to the original function throwing the exception
+        assert frames[-1][2] == 'always_fail'
+        # Traceback contains the line throwing the exception
+        assert frames[-1][3] == 'raise ValueError(x)'
+        # Traceback contains parent
+        assert frames[-2][2] == 'maybe_fail'
+        assert frames[-2][3] == 'return always_fail(x)'
+
+
+def test_future_timeout():
     def slow_future():
-        time.sleep(0.3)
+        time.sleep(10)
 
-    t0 = time.time()
     f = Future(slow_future)
-    assert time.time() - t0 < 0.1
-    f.deref()
-    assert time.time() - t0 > 0.3
+    try:
+        f.deref(1)
+    except multiprocessing.TimeoutError as e:
+        pass
 
 
 def test_pmap():
     def square(x):
         return x ** 2
 
+    # Fast fns have negligible overhead
+    t0 = time.time()
+    result = list(pmap(square, xrange(100)))
+    t1 = time.time()
+    assert t1 - t0 < 0.1
+    # Results keep ordering
+    assert result == list(map(square, xrange(100)))
+
     def slow_square(x):
-        time.sleep(0.04)
+        time.sleep(0.01)
         return x ** 2
 
+    # Slow fns scale sub-linear w/ respect to number of threads
     t0 = time.time()
-    result = pmap(square, xrange(100))
-    assert time.time() - t0 < 0.01
-    assert list(result) == list(map(square, xrange(100)))
-
-    t0 = time.time()
-    result = pmap(slow_square, xrange(100))
-    assert time.time() - t0 < 0.2
-    assert list(result) == list(map(square, xrange(100)))
+    result = list(pmap(slow_square, xrange(100), threads=100))
+    t1 = time.time()
+    assert t1 - t0 < 10.0
+    # Results keep ordering
+    assert result == list(map(square, xrange(100)))
 
 
-def test_exception_handling():
-    def deep_func(x):
-        raise ValueError(x)
-
-    def fail_func(x):
-        return deep_func(x)
-
+def test_pmap_raise_original_traceback():
     try:
-        list(pmap(fail_func, ['foo']))
-    except:
+        list(pmap(always_fail, ['foo']))
+    except ValueError:
         frames = traceback.extract_tb(sys.exc_info()[2])
-        last_frame = frames[-1]
-        # Stacktrace points to the original function throwing the exception
-        assert last_frame[2] == 'deep_func'
-        # Stacktrace contains the line throwing the exception
-        assert last_frame[3] == 'raise ValueError(x)'
+        print frames
+        assert frames[-1][2] == 'always_fail'
+        assert frames[-1][3] == 'raise ValueError(x)'


### PR DESCRIPTION
- `Future` now takes a `pool` argument to specify a thread pool.
- `Future` now implements `__call__` to allow `Future(f)("foo", k=42)` style to pass additional arguments.
- `Future.deref()` now accepts an optional `timeout` parameter to avoid blocking forever.
- Introduce `Deferred` object to encapsulate deferred results and re-throwing with original traceback.