### PR TITLE
Make pvalmap return dict-like

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 John Jacobsen <john@mail.npxdesigns.com>
 Henrique Carvalho Alves <hcarvalhoalves@gmail.com>
+Lia Bifano <liabifano@gmail.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [1.2.0]
 ### New
-- `pvalmap` map the values of a dicionary
+- `pvalmap` and `pkeymap` functions to map over the values and keys of a dictionary.
 
 ## [1.1.1]
 ### Bugfix

--- a/README.md
+++ b/README.md
@@ -1,31 +1,15 @@
+# python-pmap
+
 [Clojure's pmap](https://clojuredocs.org/clojure.core/pmap) implementation for Python.
 
-### Usage of pmap
+Multi-threaded versions of the following high-order functions are available:
 
-```
-from pmap import pmap
+| fn              | equivalent to
+| -------------   | ---------------------
+| `pmap.pmap`     | `itertools.imap`
+| `pmap.pvalmap`  | `toolz.dictoolz.valmap`
+| `pmap.pkeymap`  | `toolz.dictoolz.keymap`
 
-def fn(ele):
-	return do_some_IO(ele)
+Package also includes `pmap.Deferred` and `pmap.Future` classes that may be generally useful.
 
-seq = xrange(10000)
-
-for result in pmap(fn, seq):
-	print result
-
-```
-
-
-### Usage of pvalmap
-
-```
-from pmap import pvalmap
-
-def fn(ele):
-	return do_some_IO(ele)
-
-d = some_dict
-
-dict(pvalmap(d))
-
-```
+See included `tests/` for usage examples.

--- a/src/pmap/__init__.py
+++ b/src/pmap/__init__.py
@@ -1,3 +1,3 @@
 from .core import *
 
-__all__ = ['pmap', 'pvalmap', 'Future']
+__all__ = ['pmap', 'pvalsmap', 'Deferred', 'Future']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,6 +88,12 @@ def test_pmap_raise_original_traceback():
 def test_pvalmap():
     d = {'1': 1, '2': 2, '3': 3}
     expected = {'1': 2, '2': 3, '3': 4}
-    result = pvalmap(lambda x: x+1, d)
+    result = pvalmap(lambda x: x + 1, d)
+    assert result == expected
 
-    assert dict(result) == expected
+
+def test_pkeymap():
+    d = {'1': 1, '2': 2, '3': 3}
+    expected = {'01': 1, '02': 2, '03': 3}
+    result = pkeymap(lambda x: "0{}".format(x), d)
+    assert result == expected


### PR DESCRIPTION
This makes the function a drop-in replacement to
toolz.dicttoolz.valmap

Also include `pkeymap` analog.

Updated README.